### PR TITLE
[FEATURE] /forget slash command

### DIFF
--- a/skills/forget/SKILL.md
+++ b/skills/forget/SKILL.md
@@ -1,39 +1,70 @@
 ---
-description: Remove stored memories from ZeroDB
+description: Remove stored memories from ZeroDB by searching for matches and confirming before deletion
 ---
 
 The user wants to delete one or more memories from ZeroDB.
 
-## Steps
+## Parse the user input
 
-1. Extract the search query from the user's input (everything after `/forget`).
-2. Check for `--all` flag — if present, handle mass delete flow (see below).
-3. Call `zerodb_semantic_search` with the query, limit 10.
-4. Present matching memories for confirmation:
+Everything after `/forget` is the search query. Special flags:
+- `--all` — mass delete all memories for the current project (nuclear option)
+- `--type <type>` — filter matches to a specific memory type before presenting
 
-```
-Found 2 memories matching 'old staging URL':
+## Standard flow (no --all flag)
 
-1. [convention] Staging URL is staging.ainative.studio — use this for QA testing
-2. [architecture] Old staging environment runs on Heroku at app-xyz.herokuapp.com
+1. Extract the search query.
+2. Detect current project: run `git remote get-url origin 2>/dev/null`, normalize to `org/repo` lowercase.
+3. Call `zerodb_semantic_search` with the query, limit 20.
+4. Filter results to current project (`metadata.project`).
+5. If no matches:
+   ```
+   No memories found matching '[query]'.
+   ```
+   Stop here.
+6. Present matches numbered for confirmation:
+   ```
+   Found 2 memories matching 'old staging URL':
 
-Delete these? (yes/no)
-```
+   1. [convention] Staging URL is staging.ainative.studio — use this for QA testing
+      Stored: 2026-03-15
 
-5. If user confirms: call the appropriate delete/clear tool for each memory ID.
-6. Confirm: `Deleted 2 memories.`
-7. If no matches: `No memories found matching '[query]'.`
+   2. [architecture] Old staging environment runs on Heroku at app-xyz.herokuapp.com
+      Stored: 2026-02-01
 
-## Mass delete (--all)
+   Delete these? Type the numbers to delete (e.g. "1,2"), "all", or "cancel"
+   ```
+7. Wait for user response:
+   - Specific numbers (e.g. "1" or "1,2"): delete only those memories
+   - "all": delete all listed matches
+   - "cancel" or anything else: abort with "Cancelled — no memories deleted."
+8. Call the appropriate ZeroDB delete/clear tool for each confirmed memory.
+9. Confirm: `Deleted N memories.`
+
+## Mass delete (--all flag)
 
 If user runs `/forget --all`:
-1. Ask: `This will delete ALL memories for project [org/repo]. Type 'DELETE' to confirm.`
-2. Only proceed if user types exactly `DELETE`.
-3. Call `zerodb_clear_session` or equivalent bulk clear for the project.
-4. Confirm: `Cleared all memories for [org/repo].`
+1. Detect current project.
+2. Get total memory count for the project via `zerodb_search_memory` with broad query.
+3. Warn the user:
+   ```
+   ⚠️  This will permanently delete ALL N memories for [org/repo].
+   Type DELETE (all caps) to confirm, or anything else to cancel.
+   ```
+4. Only proceed if the user's next message is exactly `DELETE`.
+5. Call `zerodb_clear_session` or equivalent bulk clear for the project.
+6. Confirm: `Cleared all N memories for [org/repo].`
+7. If not confirmed: `Cancelled — all memories preserved.`
+
+## Error handling
+
+- If ZeroDB MCP tools are unavailable: `ZeroDB memory is not connected. Check your ZERODB_API_KEY and try again.`
+- If not in a git repo: use project = `unknown`, still proceed with search across all memories.
 
 ## Examples
 
-`/forget old staging URL`
-`/forget the celery migration note — it shipped`
-`/forget --all` (nuclear option, double confirmed)
+```
+/forget old staging URL
+/forget the celery migration note — it shipped last week
+/forget --type convention anything about port 5432
+/forget --all
+```

--- a/skills/zerodb-memory-guide/SKILL.md
+++ b/skills/zerodb-memory-guide/SKILL.md
@@ -88,8 +88,41 @@ When user runs `/recall <query>`:
 
 ## /forget command
 When user runs `/forget <query>`:
-1. Search for matching memories.
-2. Show matches and ask for confirmation before deleting.
+1. Extract the search query (everything after `/forget`). Detect flags:
+   - `--all` — mass delete all memories for the current project (nuclear option)
+   - `--type <type>` — filter results to a specific memory type before presenting
+2. Detect current project via `git remote get-url origin 2>/dev/null`, normalized to `org/repo` lowercase.
+3. Call `zerodb_semantic_search` with the query, limit 20. Filter to current project (`metadata.project`).
+4. If no matches found: `No memories found matching '[query]'.` — stop.
+5. Present numbered matches for confirmation:
+   ```
+   Found 2 memories matching 'old staging URL':
+
+   1. [convention] Staging URL is staging.ainative.studio — use this for QA testing
+      Stored: 2026-03-15
+
+   2. [architecture] Old staging environment runs on Heroku at app-xyz.herokuapp.com
+      Stored: 2026-02-01
+
+   Delete these? Type the numbers to delete (e.g. "1,2"), "all", or "cancel"
+   ```
+6. Wait for user response:
+   - Specific numbers: delete only those memories
+   - "all": delete all listed matches
+   - "cancel" or anything else: `Cancelled — no memories deleted.`
+7. Call the appropriate ZeroDB delete/clear tool, then confirm: `Deleted N memories.`
+
+### Mass delete (--all flag)
+If user runs `/forget --all`:
+1. Get total memory count via `zerodb_search_memory` with a broad query.
+2. Warn: `⚠️  This will permanently delete ALL N memories for [org/repo]. Type DELETE (all caps) to confirm, or anything else to cancel.`
+3. Only proceed if the user's next message is exactly `DELETE`.
+4. Call `zerodb_clear_session` or equivalent bulk clear.
+5. Confirm: `Cleared all N memories for [org/repo].` — or `Cancelled — all memories preserved.`
+
+### Error handling
+- If ZeroDB MCP tools are unavailable: `ZeroDB memory is not connected. Check your ZERODB_API_KEY and try again.`
+- If not in a git repo: use project = `unknown`, still proceed with search across all memories.
 
 ## Privacy — non-negotiable
 - NEVER store secrets, credentials, or PII regardless of what the user asks.


### PR DESCRIPTION
## Summary

- Replaces the placeholder `skills/forget/SKILL.md` stub with a full production-ready implementation
- Numbered match presentation with stored dates for each candidate memory
- Granular selection: user types specific numbers (e.g. `1,2`), `all`, or `cancel` — not just yes/no
- `--type <type>` flag to pre-filter matches by memory type before presenting
- `--all` nuclear option with hard double-confirmation (user must type `DELETE` in all caps)
- Project-scoped search via `git remote get-url origin`, falls back to `unknown` if not in a git repo
- Error handling when ZeroDB MCP tools are unavailable
- Expanded `/forget` section in `skills/zerodb-memory-guide/SKILL.md` to match the full flow

## Test Plan

- [ ] `/forget <query>` — shows numbered results, waits for selection, deletes on confirm
- [ ] `/forget <query>` — "cancel" aborts with no deletions
- [ ] `/forget --type convention <query>` — only shows memories of the given type
- [ ] `/forget --all` — prompts with count, only proceeds on exact `DELETE` response
- [ ] `/forget --all` — any other response cancels with preservation message
- [ ] No ZeroDB connection — returns actionable error message
- [ ] Run outside git repo — falls back to `unknown` project, searches all memories

## Risk / Rollback

Low risk — skill files only, no runtime code changes. Rollback: revert `skills/forget/SKILL.md` to the stub.

Closes #9